### PR TITLE
added Android JNI compatibility

### DIFF
--- a/src/jni.c
+++ b/src/jni.c
@@ -1,0 +1,50 @@
+#include <jni.h>
+#include "sphinx.h"
+
+JNIEXPORT void JNICALL Java_org_hsbp_androsphinx_Sphinx_challenge(JNIEnv *env, jobject ignore, jbyteArray pwd, jbyteArray bfac, jbyteArray chal) {
+	jbyte* bufferPtrPwd = (*env)->GetByteArrayElements(env, pwd, NULL);
+	jbyte* bufferPtrBfac = (*env)->GetByteArrayElements(env, bfac, NULL);
+	jbyte* bufferPtrChal = (*env)->GetByteArrayElements(env, chal, NULL);
+	jsize pwdLen = (*env)->GetArrayLength(env, pwd);
+
+	sphinx_challenge(bufferPtrPwd, pwdLen, bufferPtrBfac, bufferPtrChal);
+
+	(*env)->ReleaseByteArrayElements(env, pwd, bufferPtrPwd, JNI_ABORT);
+	(*env)->ReleaseByteArrayElements(env, bfac, bufferPtrBfac, 0);
+	(*env)->ReleaseByteArrayElements(env, chal, bufferPtrChal, 0);
+}
+
+JNIEXPORT jbyteArray JNICALL Java_org_hsbp_androsphinx_Sphinx_respond(JNIEnv *env, jobject ignore, jbyteArray chal, jbyteArray secret) {
+	jbyte* bufferPtrChal = (*env)->GetByteArrayElements(env, chal, NULL);
+	jbyte* bufferPtrSecret = (*env)->GetByteArrayElements(env, secret, NULL);
+
+	jbyteArray resp = (*env)->NewByteArray(env, SPHINX_255_SER_BYTES);
+	jbyte* bufferPtrResp = (*env)->GetByteArrayElements(env, resp, NULL);
+
+	int result = sphinx_respond(bufferPtrChal, bufferPtrSecret, bufferPtrResp);
+
+	(*env)->ReleaseByteArrayElements(env, resp, bufferPtrResp, result ? JNI_ABORT : 0);
+	(*env)->ReleaseByteArrayElements(env, chal, bufferPtrChal, JNI_ABORT);
+	(*env)->ReleaseByteArrayElements(env, secret, bufferPtrSecret, JNI_ABORT);
+
+	return result ? NULL : resp;
+}
+
+JNIEXPORT jbyteArray JNICALL Java_org_hsbp_androsphinx_Sphinx_finish(JNIEnv *env, jobject ignore, jbyteArray pwd, jbyteArray bfac, jbyteArray resp) {
+	jbyte* bufferPtrPwd = (*env)->GetByteArrayElements(env, pwd, NULL);
+	jbyte* bufferPtrBfac = (*env)->GetByteArrayElements(env, bfac, NULL);
+	jbyte* bufferPtrResp = (*env)->GetByteArrayElements(env, resp, NULL);
+	jsize pwdLen = (*env)->GetArrayLength(env, pwd);
+
+	jbyteArray rwd = (*env)->NewByteArray(env, SPHINX_255_SER_BYTES);
+	jbyte* bufferPtrRwd = (*env)->GetByteArrayElements(env, rwd, NULL);
+
+	int result = sphinx_finish(bufferPtrPwd, pwdLen, bufferPtrBfac, bufferPtrResp, bufferPtrRwd);
+
+	(*env)->ReleaseByteArrayElements(env, rwd, bufferPtrRwd, result ? JNI_ABORT : 0);
+	(*env)->ReleaseByteArrayElements(env, resp, bufferPtrResp, JNI_ABORT);
+	(*env)->ReleaseByteArrayElements(env, bfac, bufferPtrBfac, JNI_ABORT);
+	(*env)->ReleaseByteArrayElements(env, pwd, bufferPtrPwd, JNI_ABORT);
+
+	return result ? NULL : rwd;
+}

--- a/src/makefile
+++ b/src/makefile
@@ -27,6 +27,11 @@ win: MAKETARGET=win
 win: win/libsodium-win64 exe libsphinx.$(SOEXT) tests$(EXT)
 exe: bin/challenge$(EXT) bin/respond$(EXT) bin/derive$(EXT)
 
+android: INC=-Igoldilocks/src/GENERATED/include -I$(SODIUM) -I$(SODIUM)/sodium
+android: LIBS=-Wl,-Bstatic -Wl,-Bdynamic -lsodiumjni -L.
+android: EXTRA_OBJECTS=jni.o
+android: jni.o libsphinx.so
+
 tests$(EXT): tests/pake$(EXT) tests/sphinx$(EXT) tests/opaque$(EXT)
 
 $(objs):
@@ -44,8 +49,8 @@ bin/derive$(EXT): $(objs) bin/derive.c
 bin/2pass$(EXT): $(objs) bin/2pass.c
 	$(CC) $(CFLAGS) -o bin/2pass$(EXT) bin/2pass.c $(LDFLAGS) $(objs)
 
-libsphinx.$(SOEXT): $(objs) sphinx.o pake.o opaque.o
-	$(CC) -shared -fpic $(CFLAGS) -o libsphinx.$(SOEXT) $(objs) sphinx.o pake.o opaque.o $(LDFLAGS)
+libsphinx.$(SOEXT): $(objs) sphinx.o pake.o opaque.o $(EXTRA_OBJECTS)
+	$(CC) -shared -fpic $(CFLAGS) -o libsphinx.$(SOEXT) $(objs) sphinx.o pake.o opaque.o $(EXTRA_OBJECTS) $(LDFLAGS)
 
 tests/sphinx$(EXT): tests/test.c libsphinx.$(SOEXT)
 	$(CC) $(CFLAGS) -o tests/sphinx$(EXT) tests/test.c -L. -lsphinx $(LDFLAGS) $(objs)


### PR DESCRIPTION
This PR adds

 - three exported functions to the `libsphinx.so` library so that it can be called from Java(-like) environments such as Android or JVM and
 - a Makefile target that makes it possible to
   - include the above optionally,
   - supply libsodium header directory from an alternate location and
   - link to https://github.com/joshjdevl/libsodium-jni/

Based on my own tests, this shouldn't affect existing build targets in any way.