### PR TITLE
[fix] use test instead of [[ for POSIX compat

### DIFF
--- a/src/bin/tests/test.sh
+++ b/src/bin/tests/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # initialize (device) secret
-[[ -f secret ]] || {
+test -f secret || {
     echo "generating \"secret\""
     dd if=/dev/urandom of=secret bs=32 count=1 2>/dev/null
 }


### PR DESCRIPTION
Use ``test`` instead of ``[[``. The latter is undefined in POSIX. ``dash`` for example does not support this.

```
$ bash -c '[[ -f file.txt ]] || echo "does not exist"'
does not exist
$ dash -c '[[ -f file.txt ]] || echo "does not exist"'
dash: 1: [[: not found
does not exist # really ?

$ touch file.txt

$ bash -c '[[ -f file.txt ]] || echo "does not exist"'
# no output
$ dash -c '[[ -f file.txt ]] || echo "does not exist"'
dash: 1: [[: not found
does not exist # damn!
```